### PR TITLE
deploy apk after build

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,8 @@
 			"installMaven": "false",
 			"installGradle": "true"
 		},
-		"ghcr.io/nordcominc/devcontainer-features/android-sdk:1": {}
+		"ghcr.io/nordcominc/devcontainer-features/android-sdk:1": {},
+		"ghcr.io/devcontainers/features/github-cli:1": {}
 	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@
 # This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
 
-name: Build Robot Controller App
+name: Build
 
 env:
   TEAM_NAME: Botsmiths
@@ -47,6 +47,7 @@ jobs:
           ${{ runner.os }}-gradle-
 
     - name: Set BUILD_NUMBER environment variable
+      id: set-build-number
       run: |
         DATE=$(date +'%y%m')
         echo "BUILD_NUMBER=${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${DATE}.${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
@@ -65,7 +66,7 @@ jobs:
     - name: Pubish apk as an artifact
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ env.ARTIFACT_NAME }}
+        name: build-output
         path: ${{ env.ARTIFACT_NAME }}.apk
 
     - name: Create release
@@ -88,3 +89,6 @@ jobs:
         asset_path: ${{ env.ARTIFACT_NAME }}.apk
         asset_name: ${{ env.ARTIFACT_NAME }}.apk
         asset_content_type: application/vnd.android.package-archive
+
+    outputs:
+      apk_name: ${{ env.ARTIFACT_NAME }}.apk

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,7 @@
 name: Deploy
 
 on:
-  workflow_run:
-    workflows: ["Build"]
-    types:
-      - completed
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy
+
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
+
+jobs:
+  deploy:
+    name: Deploy Job
+    runs-on: self-hosted  # Uses the self-hosted runner with adb installed
+
+    # Define input parameters
+    env:
+      DEVICE_SERIAL: ${{ github.event.inputs.device_serial || '811e4b3436c7263c' }}  # Default to specific device serial
+
+    steps:
+      - name: Download Build Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: build-output
+          path: ./build  # Download to the 'build' directory
+
+      - name: Set APK Name from Build
+        run: echo "APK_NAME=${{ github.event.workflow_run.outputs.apk_name }}" >> $GITHUB_ENV
+
+      # Run adb commands to uninstall and install the APK on the specified device
+      - name: Uninstall Previous APK
+        run: adb -s $DEVICE_SERIAL uninstall com.qualcomm.ftcrobotcontroller
+
+      - name: Install New APK
+        run: adb -s $DEVICE_SERIAL install "./${{ env.APK_NAME }}"


### PR DESCRIPTION
After building, deploy via the Control Hub connected to a self-hosted agent with android's adb platform tool installed.